### PR TITLE
update aws-iam-authenticator version to 0.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazon/aws-cli
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
-    curl -o /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
+    curl -L -o /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.7/aws-iam-authenticator_0.5.7_linux_amd64 && \
     chmod +x /usr/local/bin/aws-iam-authenticator && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl 


### PR DESCRIPTION
It has support for v1beta1 api which is needed for kubectl 1.24